### PR TITLE
Enhance API service: Support basic streaming requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Now that the disclosure is complete, this project aims to offer an easy way to c
   - [x] Wrapper around fetch method to simplify usage GET, PUT, POST and DELETE
   - [ ] Support for streaming requests
 - [ ] Support for Single Sign-On through cookies
-- [ ] CSS modules injection into React Shadow
+- [x] CSS injection into React Shadow
 - [x] Support testing using Vitest
 - and much more
 
@@ -22,7 +22,7 @@ Now that the disclosure is complete, this project aims to offer an easy way to c
 - [x] Setup deployment and HMR in extension - using CXRJS
 - [x] Load React in Content Script considering there is not index.html
 - [x] Introduce Shadow dom and styles for the component
-- [ ] Global styles to use within every page (Not required)
+- [x] Global styles to use within every page (Not required)
 
 ## Tech debt to address
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Now that the disclosure is complete, this project aims to offer an easy way to c
   - [x] Concurrency handler with Error handler
   - [ ] Support for authentication through headers
   - [x] Wrapper around fetch method to simplify usage GET, PUT, POST and DELETE
-  - [ ] Support for streaming requests
+  - [x] Support for streaming requests (Caveat we wait for the whole stream to finish fetching)
 - [ ] Support for Single Sign-On through cookies
 - [x] CSS injection into React Shadow
 - [x] Support testing using Vitest

--- a/src/serviceWorker/services/base.api.ts
+++ b/src/serviceWorker/services/base.api.ts
@@ -264,11 +264,11 @@ export class BaseApi {
 
   /**
    * Retrieves authentication headers based on the provided request options.
-   * @param requestOptions The request options.
+   * @param _requestOptions The request options.
    * @returns The authentication headers.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  getAuthHeader(requestOptions: Partial<Request>) {
+  getAuthHeader(_requestOptions: Partial<Request>) {
     return {
       Authorization: "Auth",
     }


### PR DESCRIPTION
# Changelog

- Add support for basic stream fetching


## Consideration

- We are prepared to wait for the stream to complete before progressing with the execution flow, as we rely on the data for tasks like Bloom filter fetching and other related approaches.